### PR TITLE
removed platypusOptions line

### DIFF
--- a/tools/platypus-callVariants.nix
+++ b/tools/platypus-callVariants.nix
@@ -37,6 +37,9 @@ stage {
 
     # Remove timestamps from output
     sed -i '/^##fileDate/d' $out
+
+    # Remove platypusOptions from output
+    sed -i '/^##platypusOptions/d' $out
   '';
   passthru.filetype = filetype.vcf { inherit ref; };
   passthru.multicore = true;


### PR DESCRIPTION
Originally `bionix.platypus.call` would output a platypusOptions line with system information, but this would make the output nondeterministic, so this modification strips that line from the output.