### PR TITLE
samtools.queryRegion: queries regions from a fasta file

### DIFF
--- a/tools/samtools-queryRegion.nix
+++ b/tools/samtools-queryRegion.nix
@@ -1,0 +1,22 @@
+{ bionix
+, flags ? null
+, regions ? []
+}:
+
+input:
+
+with bionix;
+with lib;
+with types;
+
+assert (matchFiletype "samtools-queryRegion" { fa = _: true; } input);
+
+stage {
+
+  name = "samtools-faidx";
+  buildInputs = with pkgs; [ samtools ];
+  buildCommand = ''
+    ln -s ${input} input.fasta
+    samtools faidx ${optionalString (flags != null) flags} input.fasta ${concatStringsSep " " regions} > $out
+  '';
+}

--- a/tools/samtools.nix
+++ b/tools/samtools.nix
@@ -13,4 +13,5 @@ with bionix;
   markdup = callBionixE ./samtools-markdup.nix;
   fixmate = callBionixE ./samtools-fixmate.nix;
   tabix = callBionixE ./samtools-tabix.nix;
+  queryRegion = callBionixE ./samtools-queryRegion.nix;
 }


### PR DESCRIPTION
https://github.com/PapenfussLab/bionix/issues/22
`samtools faidx` has two functionalities: indexing and region querying. Currently BioNix only uses the indexing functionality. `samtools.queryRegion` serves the region querying functionality.